### PR TITLE
fix: Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "@tazama-lf/auth-lib",
   "version": "1.0.0",
   "description": "Authentication Library for Tazama",
+  "author": {
+    "name": "Tazama",
+    "email": "engineering@tazama.org",
+    "url": "https://tazama.org"
+  },
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc --project tsconfig.json",
@@ -59,7 +64,9 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "tslib": "^2.6.3",
+    "dotenv": "^16.4.5"
   },
   "lint-staged": {
     "*.{js,ts}": [


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Add the following in package.json
- author block
- `tslib` and `dotenv` dependancy

## Why are we doing this?

They were missing from it which affected the package usage

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
