### PR TITLE
tenantId added to the iTazamaToken interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This file contains utility functions for validating tokens and their claims. The
 [src/services/tazamaService.ts]()
 
 ### src/interfaces/iTazamaToken.ts
-This file defines the TazamaToken interface which outlines the structure of a token. It includes properties like `exp` (expiration time), `sid` (session ID), `iss` (issuer), `tokenString`, `clientId`, and `claims` (an array of strings representing the token's claims). It also defines the ClaimValidationResult type.
+This file defines the TazamaToken interface which outlines the structure of a token. It includes properties like `exp` (expiration time), `sid` (session ID), `iss` (issuer), `tokenString`, `clientId`, `tenantId`, and `claims` (an array of strings representing the token's claims). It also defines the ClaimValidationResult type.
 
 [src/interfaces/iTazamaToken.ts]()
 

--- a/src/interfaces/iTazamaToken.ts
+++ b/src/interfaces/iTazamaToken.ts
@@ -1,12 +1,13 @@
 import type jwt from 'jsonwebtoken';
 
 interface TazamaToken extends jwt.JwtPayload {
-  claims: string[];
-  clientId: string;
   exp: number;
-  iss: string;
   sid: string;
+  iss: string;
   tokenString: string;
+  clientId: string;
+  tenantId: string;
+  claims: string[];
 }
 
 type ClaimValidationResult = Record<string, boolean>;


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Added tenantId attribute to the iTazamaToken interface.

## Why are we doing this?
Identify user tenant based on tenantId.
## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
