### PR TITLE
build: Version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/auth-lib",
-  "version": "2.1.0",
+  "version": "2.2.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/auth-lib",
-      "version": "2.1.0",
+      "version": "2.2.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonwebtoken": "^9.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/auth-lib",
-  "version": "2.1.0",
+  "version": "2.2.0-rc.0",
   "description": "Authentication Library for Tazama",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Library Version

## Why are we doing this?

So we can publish a new RC Release for integration testing with the rest of the platform regarding the tenantID solution.

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
