### PR TITLE
fix: throw instead of silently assigning 'DEFAULT' in case of missing tenant_id

### DIFF
--- a/__tests__/unit/services.test.ts
+++ b/__tests__/unit/services.test.ts
@@ -770,35 +770,39 @@ describe('Tenant Service', () => {
       const result = extractTenant(true, 'Bearer valid-token');
 
       expect(result.success).toBe(true);
-      expect(result.tenantId).toBe('test-tenant');
+      if (result.success) {
+        expect(result.tenantId).toBe('test-tenant');
+      }
     });
 
     it('should return failure when authenticated but no authorization header is provided', () => {
       const result = extractTenant(true);
 
       expect(result.success).toBe(false);
-      expect(result.tenantId).toBeUndefined();
     });
 
     it('should return failure when authenticated but authorization header is undefined', () => {
       const result = extractTenant(true, undefined);
 
       expect(result.success).toBe(false);
-      expect(result.tenantId).toBeUndefined();
     });
 
     it('should return DEFAULT tenant when not authenticated', () => {
       const result = extractTenant(false);
 
       expect(result.success).toBe(true);
-      expect(result.tenantId).toBe('DEFAULT');
+      if (result.success) {
+        expect(result.tenantId).toBe('DEFAULT');
+      }
     });
 
     it('should return DEFAULT tenant when not authenticated even with header provided', () => {
       const result = extractTenant(false, 'Bearer some-token');
 
       expect(result.success).toBe(true);
-      expect(result.tenantId).toBe('DEFAULT');
+      if (result.success) {
+        expect(result.tenantId).toBe('DEFAULT');
+      }
     });
 
     it('should extract tenant ID from token with proper Bearer format', () => {
@@ -817,7 +821,9 @@ describe('Tenant Service', () => {
       const result = extractTenant(true, 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...');
 
       expect(result.success).toBe(true);
-      expect(result.tenantId).toBe('bearer-tenant');
+      if (result.success) {
+        expect(result.tenantId).toBe('bearer-tenant');
+      }
     });
 
     it('should handle verifyToken returning token with different tenant ID', () => {
@@ -836,7 +842,9 @@ describe('Tenant Service', () => {
       const result = extractTenant(true, 'Bearer mock-jwt-token');
 
       expect(result.success).toBe(true);
-      expect(result.tenantId).toBe('tenant123');
+      if (result.success) {
+        expect(result.tenantId).toBe('tenant123');
+      }
     });
 
     it('should handle verifyToken being called with correct token from authorization header', () => {
@@ -872,12 +880,16 @@ describe('Tenant Service', () => {
       // Test with different spacing
       const result1 = extractTenant(true, 'Bearer token123');
       expect(result1.success).toBe(true);
-      expect(result1.tenantId).toBe('format-tenant');
+      if (result1.success) {
+        expect(result1.tenantId).toBe('format-tenant');
+      }
 
       // Test with multiple spaces (should split correctly)
       const result2 = extractTenant(true, 'Bearer  token-with-spaces');
       expect(result2.success).toBe(true);
-      expect(result2.tenantId).toBe('format-tenant');
+      if (result2.success) {
+        expect(result2.tenantId).toBe('format-tenant');
+      }
     });
 
     it('should handle the case when verifyToken throws an error', () => {
@@ -908,12 +920,122 @@ describe('Tenant Service', () => {
       // Test with only "Bearer" (no token part)
       const result1 = extractTenant(true, 'Bearer');
       expect(result1.success).toBe(true);
-      expect(result1.tenantId).toBe('split-tenant');
+      if (result1.success) {
+        expect(result1.tenantId).toBe('split-tenant');
+      }
 
       // Test with empty string after Bearer
       const result2 = extractTenant(true, 'Bearer ');
       expect(result2.success).toBe(true);
-      expect(result2.tenantId).toBe('split-tenant');
+      if (result2.success) {
+        expect(result2.tenantId).toBe('split-tenant');
+      }
+    });
+
+    // Security fix tests for issue #170
+    describe('security: tenant isolation (issue #170)', () => {
+      it('should return failure when authenticated=true and decoded token has no tenantId property', () => {
+        // Mock verifyToken to return a token WITHOUT tenantId property
+        jest.spyOn(require('../../src/services/jwtService'), 'verifyToken').mockReturnValue({
+          sub: 'test-user',
+          iss: 'test-issuer',
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          sid: 'test-session',
+          tokenString: 'test-token',
+          clientId: 'test-client',
+          // tenantId is missing
+          claims: ['test-claim'],
+        });
+
+        const result = extractTenant(true, 'Bearer valid-token-no-tenant');
+
+        expect(result.success).toBe(false);
+      });
+
+      it('should return failure when authenticated=true and tenantId is undefined', () => {
+        // Mock verifyToken to return a token with tenantId explicitly set to undefined
+        jest.spyOn(require('../../src/services/jwtService'), 'verifyToken').mockReturnValue({
+          sub: 'test-user',
+          iss: 'test-issuer',
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          sid: 'test-session',
+          tokenString: 'test-token',
+          clientId: 'test-client',
+          tenantId: undefined,
+          claims: ['test-claim'],
+        });
+
+        const result = extractTenant(true, 'Bearer token-with-undefined-tenant');
+
+        expect(result.success).toBe(false);
+      });
+
+      it('should return failure when authenticated=true and tenantId is null', () => {
+        // Mock verifyToken to return a token with tenantId set to null
+        jest.spyOn(require('../../src/services/jwtService'), 'verifyToken').mockReturnValue({
+          sub: 'test-user',
+          iss: 'test-issuer',
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          sid: 'test-session',
+          tokenString: 'test-token',
+          clientId: 'test-client',
+          tenantId: null,
+          claims: ['test-claim'],
+        });
+
+        const result = extractTenant(true, 'Bearer token-with-null-tenant');
+
+        expect(result.success).toBe(false);
+      });
+
+      it('should return failure when authenticated=true and tenantId is empty string', () => {
+        // Mock verifyToken to return a token with tenantId set to empty string
+        jest.spyOn(require('../../src/services/jwtService'), 'verifyToken').mockReturnValue({
+          sub: 'test-user',
+          iss: 'test-issuer',
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          sid: 'test-session',
+          tokenString: 'test-token',
+          clientId: 'test-client',
+          tenantId: '',
+          claims: ['test-claim'],
+        });
+
+        const result = extractTenant(true, 'Bearer token-with-empty-tenant');
+
+        expect(result.success).toBe(false);
+      });
+
+      it('should still return DEFAULT tenant when authenticated=false (no-auth mode unchanged)', () => {
+        // Verify that the no-auth path is not affected by the security fix
+        const result = extractTenant(false);
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.tenantId).toBe('DEFAULT');
+        }
+      });
+
+      it('should accept valid tenantId when authenticated=true (positive test)', () => {
+        // Mock verifyToken to return a token with a valid tenantId
+        jest.spyOn(require('../../src/services/jwtService'), 'verifyToken').mockReturnValue({
+          sub: 'test-user',
+          iss: 'test-issuer',
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          sid: 'test-session',
+          tokenString: 'test-token',
+          clientId: 'test-client',
+          tenantId: 'valid-tenant-123',
+          claims: ['test-claim'],
+        });
+
+        const result = extractTenant(true, 'Bearer valid-token');
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.tenantId).toBe('valid-tenant-123');
+        }
+      });
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/auth-lib",
-  "version": "4.0.0-rc.4",
+  "version": "4.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/auth-lib",
-      "version": "4.0.0-rc.4",
+      "version": "4.0.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonwebtoken": "^9.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/auth-lib",
-  "version": "4.0.0-rc.3",
+  "version": "4.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/auth-lib",
-      "version": "4.0.0-rc.3",
+      "version": "4.0.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonwebtoken": "^9.0.2"
@@ -67,7 +67,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -575,40 +574,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
@@ -1424,19 +1389,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1543,17 +1495,6 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1683,7 +1624,6 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1747,7 +1687,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -1953,261 +1892,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
@@ -2228,7 +1912,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2678,7 +2361,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3558,7 +3240,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4304,21 +3985,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -5407,7 +5073,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8178,7 +7843,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8380,7 +8044,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/auth-lib",
-  "version": "4.0.0-rc.4",
+  "version": "4.0.0-rc.5",
   "description": "Authentication Library for Tazama",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as AuthProviderConfig from './services/providerHelper';
 import * as JwtService from './services/jwtService';
 import { TazamaAuthentication, type TazamaAuthProvider } from './services/tazamaAuthentication';
 import { validateTokenAndClaims } from './services/tazamaService';
-import { extractTenant } from './services/tenantService';
+import { extractTenant, type ExtractTenantResult } from './services/tenantService';
 import type { TazamaUser } from './interfaces/iTazamaUser';
 
 // Providers
@@ -12,5 +12,5 @@ export type { TazamaAuthProvider, TazamaToken };
 
 // Clients
 export { validateTokenAndClaims, extractTenant };
-export type { TazamaUser };
+export type { TazamaUser, ExtractTenantResult };
 export type { ClaimValidationResult };

--- a/src/services/keycloakService.ts
+++ b/src/services/keycloakService.ts
@@ -88,13 +88,18 @@ export class KeycloakService implements IAuthenticationService {
       throw new Error(`Token is missing required properties: sub: ${typedToken.sub}, iss: ${typedToken.iss}, exp: ${typedToken.exp}`);
     }
 
+    const tenantId = typedToken.tenantId ?? typedToken.TENANT_ID;
+    if (!tenantId) {
+      throw new Error('Token is missing required tenant_id claim. User must be assigned to a tenant group in Keycloak.');
+    }
+
     return await Promise.resolve({
       clientId: typedToken.sub,
       iss: typedToken.iss,
       sid: typedToken.sid ?? '', // Provide empty string if sid is undefined
       exp: typedToken.exp,
       tokenString: authToken.accessToken,
-      tenantId: typedToken.tenantId ?? typedToken.TENANT_ID ?? 'DEFAULT', // Support both tenantId and TENANT_ID for backward compatibility
+      tenantId,
       claims: this.mapTazamaRoles(typedToken),
     });
   }

--- a/src/services/tenantService.ts
+++ b/src/services/tenantService.ts
@@ -2,6 +2,13 @@ import type { TazamaToken } from '../interfaces/iTazamaToken';
 import { verifyToken } from './jwtService';
 
 /**
+ * Result type for tenant extraction operations
+ * - When successful, includes the tenantId
+ * - When failed, no tenantId is provided
+ */
+export type ExtractTenantResult = { success: true; tenantId: string } | { success: false };
+
+/**
  * Extracts tenant information from an authorization header or returns a default tenant.
  *
  * @param authenticated - Whether the request is authenticated
@@ -21,19 +28,25 @@ import { verifyToken } from './jwtService';
  * // For authenticated request without header
  * const result = extractTenant(true);
  * // Returns: { success: false }
+ *
+ * // For authenticated request with token missing tenantId
+ * const result = extractTenant(true, "Bearer <token-without-tenantId>");
+ * // Returns: { success: false }
  * ```
  *
  * @remarks
  * - If authenticated is false, returns success with 'DEFAULT' as tenantId
  * - If authenticated is true but no authorization header is provided, returns failure
  * - If authenticated is true and header is provided, extracts and verifies the JWT token
+ * - If authenticated is true and the decoded token does not contain tenantId, returns failure (security fix for #170)
  * - Expects authorization header in format "Bearer <token>"
  */
-export const extractTenant = (authenticated: boolean, authorizationHeader?: string): { success: boolean; tenantId?: string } => {
+export const extractTenant = (authenticated: boolean, authorizationHeader?: string): ExtractTenantResult => {
   if (authenticated) {
     if (!authorizationHeader) return { success: false };
     const token = authorizationHeader?.split(' ')[1];
     const decodedToken = verifyToken(token) as TazamaToken;
+    if (!decodedToken.tenantId) return { success: false };
     return {
       success: true,
       tenantId: decodedToken.tenantId,


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Bug Fix.

## Why are we doing this?
To throw error of missing tenant_id instead of silently assigning 'DEFAULT'

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
